### PR TITLE
Fix dictionary syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ class ThiagoNeyE:
         self.skills = {
             'Languages': ['Python', 'MATLAB', 'Shell'],
             'Software Engineering': ['Object-Orientation', 'SOLID', 'Design Patterns'],
-            'Quality Assurance', ['Unittest'],
-            'Data Science', ['Machine Learning'],
-            'Data Engineering', ['Apache Hop', 'Apache Beam'],
+            'Quality Assurance': ['Unittest'],
+            'Data Science': ['Machine Learning'],
+            'Data Engineering': ['Apache Hop', 'Apache Beam'],
             'Database': ['SQL', 'MySQL', 'SQL Server', 'PostgreSQL', 'SQLite', 'NoSQL', 'MongoDB', 'Redis'],
             'DataViz': ['Microsoft Power BI'],
             'Tools': ['Git', 'GitHub'],
             'OS': ['Windows', 'Linux'],
-            'Others': ['Microsoft Office', 'Microsoft Power Apps' 'Microsoft Power Automate', 'LaTeX']
+            'Others': ['Microsoft Office', 'Microsoft Power Apps', 'Microsoft Power Automate', 'LaTeX']
         }
 
     def learning(self, category: str, new: list) -> None:
@@ -40,7 +40,7 @@ class ThiagoNeyE:
 # Main 
 
 if __name__ == '__main__':
-    me = thiagoneye()
+    me = ThiagoNeyE()
     me.learning('Data Science', ['Artificial intelligence', 'Deep Learning'])
     me.learning('Data Engineering', ['Airflow'])
     me.learning('CI/CD', ['Docker'])


### PR DESCRIPTION
## Summary
- correct dictionary syntax in README example
- use proper class name in example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f363326a08326932f4989a7a19256